### PR TITLE
Add project structure and data manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # DominoLeague
-Juego de domino
+
+Juego de dominó
+
+## Estructura de proyectos y escenas
+
+```
+scenes/
+  main/MainScene.gd        # Menú principal y acceso a modos de juego
+  game/GameScene.gd        # Lógica de la mesa de dominó
+  ui/CreateTablePopup.gd   # Pop‑ups para creación de mesa
+  ui/ResultsPopup.gd       # Pop‑ups para resultados de partida
+scripts/
+  DataManager.gd           # Guardado y carga de datos de jugador
+```
+
+### Escena Principal
+Contiene el menú principal con acceso a los distintos modos de juego, la tienda y el perfil del jugador.
+
+### Escena de Juego
+Incluye la mesa de dominó y la interfaz de usuario necesaria para gestionar las fichas durante la partida.
+
+### Escenas de UI Adicionales
+Pop‑ups y pantallas auxiliares como la creación de mesa, selección de modos o resultados finales.
+
+### Gestión de Datos
+El script `DataManager.gd` implementa un sistema de guardado y carga para el perfil del jugador y otras configuraciones usando un archivo JSON.

--- a/scenes/game/GameScene.gd
+++ b/scenes/game/GameScene.gd
@@ -1,0 +1,1 @@
+extends Node\n\n# Placeholder for game logic

--- a/scenes/main/MainScene.gd
+++ b/scenes/main/MainScene.gd
@@ -1,0 +1,1 @@
+extends Node\n\n# Placeholder for main menu logic

--- a/scenes/ui/CreateTablePopup.gd
+++ b/scenes/ui/CreateTablePopup.gd
@@ -1,0 +1,1 @@
+extends Node\n\n# Placeholder for create table popup

--- a/scenes/ui/ResultsPopup.gd
+++ b/scenes/ui/ResultsPopup.gd
@@ -1,0 +1,1 @@
+extends Node\n\n# Placeholder for results popup

--- a/scripts/DataManager.gd
+++ b/scripts/DataManager.gd
@@ -1,0 +1,17 @@
+extends Node
+
+var save_path := "user://player_data.json"
+
+func save_player_data(data: Dictionary) -> void:
+    var file := File.new()
+    if file.open(save_path, File.WRITE) == OK:
+        file.store_string(to_json(data))
+        file.close()
+
+func load_player_data() -> Dictionary:
+    var file := File.new()
+    if file.file_exists(save_path) and file.open(save_path, File.READ) == OK:
+        var data := parse_json(file.get_as_text())
+        file.close()
+        return data
+    return {}


### PR DESCRIPTION
## Summary
- set up directories for scenes and scripts
- add placeholder scene scripts
- add `DataManager.gd` for saving/loading
- update README with project and scene structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b824d720832c905616ca0b1f4a08