### PR TITLE
Add basic game flow state machine

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -5,10 +5,35 @@ public class GameManager : MonoBehaviour
 {
     public DominoBoard Board;
     public List<Player> Players = new List<Player>();
+    public GameStateMachine StateMachine = new GameStateMachine();
 
     private void Start()
     {
         Players.Add(new Player("Player 1"));
         Players.Add(new Player("Player 2"));
+
+        StateMachine.OnStateChanged += HandleStateChange;
+        StateMachine.ChangeState(GameFlowState.Reparto);
+    }
+
+    private void HandleStateChange(GameFlowState newState)
+    {
+        Debug.Log($"Game state changed to: {newState}");
+    }
+
+    public void AdvanceGame()
+    {
+        switch (StateMachine.CurrentState)
+        {
+            case GameFlowState.Reparto:
+                StateMachine.ChangeState(GameFlowState.TurnoJugador);
+                break;
+            case GameFlowState.TurnoJugador:
+                StateMachine.ChangeState(GameFlowState.FinRonda);
+                break;
+            case GameFlowState.FinRonda:
+                StateMachine.ChangeState(GameFlowState.FinPartida);
+                break;
+        }
     }
 }

--- a/Assets/Scripts/GameStateMachine.cs
+++ b/Assets/Scripts/GameStateMachine.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+public enum GameFlowState
+{
+    Reparto,
+    TurnoJugador,
+    FinRonda,
+    FinPartida
+}
+
+public class GameStateMachine
+{
+    public GameFlowState CurrentState { get; private set; } = GameFlowState.Reparto;
+
+    public delegate void StateChangeHandler(GameFlowState newState);
+    public event StateChangeHandler OnStateChanged;
+
+    public void ChangeState(GameFlowState newState)
+    {
+        if (CurrentState == newState)
+            return;
+
+        CurrentState = newState;
+        OnStateChanged?.Invoke(CurrentState);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Proyecto basico de un juego de dominó desarrollado en Unity.
 
 - `Assets/Scenes` - Carpeta para las escenas del juego.
 - `Assets/Scripts` - Contiene los scripts en C# que definen las principales clases:
-  - `GameManager` gestiona el flujo del juego.
+- `GameManager` gestiona el flujo del juego.
+  - `GameStateMachine` define los estados de la partida y permite cambiar entre ellos.
   - `DominoTile` representa una ficha.
   - `Player` mantiene la mano de un jugador.
   - `DominoBoard` administra las fichas en la mesa.


### PR DESCRIPTION
## Summary
- implement `GameStateMachine` with states for dealing, player turn, round end and match end
- integrate the new state machine into `GameManager`
- update README with the new script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862e6c62a8c832caa015e295de8d673