### PR TITLE
Implement domino tile gameplay logic

### DIFF
--- a/Assets/Scripts/DominoBoard.cs
+++ b/Assets/Scripts/DominoBoard.cs
@@ -5,8 +5,50 @@ public class DominoBoard : MonoBehaviour
 {
     public List<DominoTile> Tiles = new List<DominoTile>();
 
-    public void AddTile(DominoTile tile)
+    public int LeftValue => Tiles.Count > 0 ? Tiles[0].Left : -1;
+    public int RightValue => Tiles.Count > 0 ? Tiles[Tiles.Count - 1].Right : -1;
+
+    public bool CanPlaceLeft(DominoTile tile)
     {
-        Tiles.Add(tile);
+        if (Tiles.Count == 0)
+            return true;
+
+        return tile.Left == LeftValue || tile.Right == LeftValue;
+    }
+
+    public bool CanPlaceRight(DominoTile tile)
+    {
+        if (Tiles.Count == 0)
+            return true;
+
+        return tile.Left == RightValue || tile.Right == RightValue;
+    }
+
+    public void PlaceLeft(DominoTile tile)
+    {
+        if (Tiles.Count == 0)
+        {
+            Tiles.Add(tile);
+            return;
+        }
+
+        if (tile.Right == LeftValue)
+            Tiles.Insert(0, tile);
+        else if (tile.Left == LeftValue)
+            Tiles.Insert(0, tile.Flip());
+    }
+
+    public void PlaceRight(DominoTile tile)
+    {
+        if (Tiles.Count == 0)
+        {
+            Tiles.Add(tile);
+            return;
+        }
+
+        if (tile.Left == RightValue)
+            Tiles.Add(tile);
+        else if (tile.Right == RightValue)
+            Tiles.Add(tile.Flip());
     }
 }

--- a/Assets/Scripts/DominoTile.cs
+++ b/Assets/Scripts/DominoTile.cs
@@ -11,4 +11,9 @@ public class DominoTile
         Left = left;
         Right = right;
     }
+
+    public DominoTile Flip()
+    {
+        return new DominoTile(Right, Left);
+    }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -6,11 +6,16 @@ public class GameManager : MonoBehaviour
     public DominoBoard Board;
     public List<Player> Players = new List<Player>();
     public GameStateMachine StateMachine = new GameStateMachine();
+    public List<DominoTile> Deck = new List<DominoTile>();
 
     private void Start()
     {
         Players.Add(new Player("Player 1"));
         Players.Add(new Player("Player 2"));
+
+        CreateDeck();
+        ShuffleDeck();
+        DealTiles();
 
         StateMachine.OnStateChanged += HandleStateChange;
         StateMachine.ChangeState(GameFlowState.Reparto);
@@ -34,6 +39,48 @@ public class GameManager : MonoBehaviour
             case GameFlowState.FinRonda:
                 StateMachine.ChangeState(GameFlowState.FinPartida);
                 break;
+        }
+    }
+
+    private void CreateDeck()
+    {
+        Deck.Clear();
+        for (int i = 0; i <= 6; i++)
+        {
+            for (int j = i; j <= 6; j++)
+            {
+                Deck.Add(new DominoTile(i, j));
+            }
+        }
+    }
+
+    private void ShuffleDeck()
+    {
+        System.Random rng = new System.Random();
+        int n = Deck.Count;
+        while (n > 1)
+        {
+            n--;
+            int k = rng.Next(n + 1);
+            DominoTile value = Deck[k];
+            Deck[k] = Deck[n];
+            Deck[n] = value;
+        }
+    }
+
+    private void DealTiles()
+    {
+        int tilesPerPlayer = 7;
+        foreach (Player p in Players)
+        {
+            for (int i = 0; i < tilesPerPlayer; i++)
+            {
+                if (Deck.Count == 0)
+                    break;
+                DominoTile tile = Deck[0];
+                Deck.RemoveAt(0);
+                p.AddTile(tile);
+            }
         }
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -15,4 +15,22 @@ public class Player
     {
         Hand.Add(tile);
     }
+
+    public bool PlayTile(DominoTile tile, DominoBoard board, bool placeLeft)
+    {
+        if (!Hand.Contains(tile))
+            return false;
+
+        bool canPlace = placeLeft ? board.CanPlaceLeft(tile) : board.CanPlaceRight(tile);
+        if (!canPlace)
+            return false;
+
+        if (placeLeft)
+            board.PlaceLeft(tile);
+        else
+            board.PlaceRight(tile);
+
+        Hand.Remove(tile);
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- add ability to flip a `DominoTile`
- expand `DominoBoard` with validation and placement logic
- allow `Player` to play tiles on the board
- generate a domino deck, shuffle and deal in `GameManager`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fd0c18a4832c93981812e2165f6a