### PR TITLE
Add UI manager to visualize domino play

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -9,6 +9,11 @@ public class GameManager : MonoBehaviour
     public List<DominoTile> Deck = new List<DominoTile>();
 
     private int currentPlayerIndex = 0;
+    /// <summary>
+    /// Exposes the index of the player whose turn is currently active so
+    /// that UI elements can display turn information.
+    /// </summary>
+    public int CurrentPlayerIndex => currentPlayerIndex;
     private int passCount = 0;
     private bool gameEnded = false;
 

--- a/Assets/Scripts/UI/DominoUIManager.cs
+++ b/Assets/Scripts/UI/DominoUIManager.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Simple UI manager that prints the current board state,
+/// the player's hand, a basic scoreboard and whose turn it is.
+/// This is intended for a very small offline prototype.
+/// </summary>
+public class DominoUIManager : MonoBehaviour
+{
+    public GameManager GameManager;
+
+    [Header("UI References")]
+    public Text PlayerHandText;
+    public Text BoardText;
+    public Text ScoreText;
+    public Text TurnText;
+
+    private void Start()
+    {
+        UpdateUI();
+    }
+
+    private void Update()
+    {
+        if (GameManager != null)
+        {
+            UpdateUI();
+        }
+    }
+
+    private void UpdateUI()
+    {
+        if (GameManager == null)
+            return;
+
+        UpdateTurnText();
+        UpdateBoardText();
+        UpdateHandText();
+        UpdateScoreText();
+    }
+
+    private void UpdateTurnText()
+    {
+        int index = GameManager.CurrentPlayerIndex;
+        if (index >= 0 && index < GameManager.Players.Count)
+        {
+            TurnText.text = $"Turno: {GameManager.Players[index].Name}";
+        }
+    }
+
+    private void UpdateBoardText()
+    {
+        StringBuilder sb = new StringBuilder();
+        foreach (var tile in GameManager.Board.Tiles)
+        {
+            sb.Append($"[{tile.Left}|{tile.Right}] ");
+        }
+        BoardText.text = sb.ToString();
+    }
+
+    private void UpdateHandText()
+    {
+        int index = GameManager.CurrentPlayerIndex;
+        if (index < 0 || index >= GameManager.Players.Count)
+            return;
+
+        StringBuilder sb = new StringBuilder();
+        foreach (var tile in GameManager.Players[index].Hand)
+        {
+            sb.Append($"[{tile.Left}|{tile.Right}] ");
+        }
+        PlayerHandText.text = sb.ToString();
+    }
+
+    private void UpdateScoreText()
+    {
+        StringBuilder sb = new StringBuilder();
+        foreach (var player in GameManager.Players)
+        {
+            sb.AppendLine($"{player.Name}: {player.Hand.Count} fichas");
+        }
+        ScoreText.text = sb.ToString();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ un jugador se queda sin fichas o la mesa queda trancada.
   - `Jugador` almacena la información del jugador (ID, nombre, monedas y rango).
   - `Ficha` es la pieza individual de dominó utilizada en la partida.
   - `DataManager` gestiona el guardado y carga del progreso del jugador.
+  - `UI/DominoUIManager` actualiza la representación visual de la mano,
+    las fichas en la mesa, un marcador y el indicador de turno.
 
 Para abrir el proyecto simplemente copie la carpeta en su workspace de Unity y abra la escena principal.
 


### PR DESCRIPTION
## Summary
- expose `CurrentPlayerIndex` in `GameManager`
- document UI manager
- add `DominoUIManager` script with simple turn/board/hand/score display

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_686301f05f04832cb0e6c696d2706d8b